### PR TITLE
GH-36 Use PHP Alpine image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     networks:
       - default
   php:
-    image: php:7.1.6-fpm
+    image: php:7.1.6-fpm-alpine
     working_dir: /var/www/app
     volumes:
       - ./:/var/www/app


### PR DESCRIPTION
closes GH-36

Turned out to be non-issue as the php docker image ships with all the required extensions.